### PR TITLE
fix: axios errors

### DIFF
--- a/src/components/bb/QuestionForm.vue
+++ b/src/components/bb/QuestionForm.vue
@@ -29,9 +29,9 @@ export default {
       this.questions = questions;
     },
     addQuestion() {
-      const header = getHeader();
+      const headers = getHeader();
       const url = 'csc/questions/create';
-      axios.post(url, {}, header)
+      axios.post(url, {}, headers)
         .then(response => {
           switch (response.status) {
             case 201:

--- a/src/components/bb/QuestionForm.vue
+++ b/src/components/bb/QuestionForm.vue
@@ -35,7 +35,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 201:
-              return response.json();
+              return response.data;
             default:
               throw new Error('Bad method!');
           }

--- a/src/components/bb/QuestionPreview.vue
+++ b/src/components/bb/QuestionPreview.vue
@@ -1,14 +1,13 @@
 <template>
   <li v-if="!hidden">
     <label class="block text-gray-700 text-sm font-bold mb-2">
-      Question {{ index+1 }}
+      Question {{ index + 1 }}
     </label>
     <div class="flex">
-      <input
-        v-model="value"
+      <input v-model="value"
         class="shadow appearance-none border rounded-l-xl w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-        @blur="saveQuestion"/>
-      <DeleteButton :onClick="deleteQuestion"/>
+        @blur="saveQuestion" />
+      <DeleteButton :onClick="deleteQuestion" />
     </div>
     <p class="text-ns" v-if="!this.value">Question cannot be left blank!</p>
   </li>
@@ -53,7 +52,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 200:
-              return response.json();
+              return response.data;
             default:
               throw new Error('Bad method!');
           }
@@ -74,7 +73,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 200:
-              return response.json();
+              return response.data;
             default:
               throw new Error('Bad method!');
           }

--- a/src/components/bb/QuestionPreview.vue
+++ b/src/components/bb/QuestionPreview.vue
@@ -47,9 +47,9 @@ export default {
   components: { DeleteButton },
   methods: {
     saveQuestion() {
-      const header = getHeader();
+      const headers = getHeader();
       const url = getUrl(`csc/questions/${this.id}`);
-      axios.put(url, { content: this.content }, { header })
+      axios.put(url, { content: this.content }, { headers })
         .then(response => {
           switch (response.status) {
             case 200:
@@ -68,9 +68,9 @@ export default {
         });
     },
     deleteQuestion() {
-      const header = getHeader();
+      const headers = getHeader();
       const url = getUrl(`csc/questions/${this.id}`);
-      axios.delete(url, {}, { header })
+      axios.delete(url, {}, { headers })
         .then(response => {
           switch (response.status) {
             case 200:

--- a/src/components/csc/QuestionForm.vue
+++ b/src/components/csc/QuestionForm.vue
@@ -29,9 +29,9 @@ export default {
       this.questions = questions;
     },
     addQuestion() {
-      const header = getHeader();
+      const headers = getHeader();
       const url = 'csc/questions/create';
-      axios.post(url, {}, header)
+      axios.post(url, {}, headers)
         .then(response => {
           switch (response.status) {
             case 201:

--- a/src/components/csc/QuestionForm.vue
+++ b/src/components/csc/QuestionForm.vue
@@ -35,7 +35,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 201:
-              return response.json();
+              return response.data;
             default:
               throw new Error('Bad method!');
           }

--- a/src/components/csc/QuestionPreview.vue
+++ b/src/components/csc/QuestionPreview.vue
@@ -53,7 +53,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 200:
-              return response.json();
+              return response.data;
             default:
               throw new Error('Bad method!');
           }
@@ -74,7 +74,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 200:
-              return response.json();
+              return response.data;
             default:
               throw new Error('Bad method!');
           }

--- a/src/components/csc/QuestionPreview.vue
+++ b/src/components/csc/QuestionPreview.vue
@@ -47,9 +47,9 @@ export default {
   components: { DeleteButton },
   methods: {
     saveQuestion() {
-      const header = getHeader();
+      const headers = getHeader();
       const url = getUrl(`csc/questions/${this.id}`);
-      axios.put(url, { content: this.content }, { header })
+      axios.put(url, { content: this.content }, { headers })
         .then(response => {
           switch (response.status) {
             case 200:
@@ -68,9 +68,9 @@ export default {
         });
     },
     deleteQuestion() {
-      const header = getHeader();
+      const headers = getHeader();
       const url = getUrl(`csc/questions/${this.id}`);
-      axios.delete(url, { id: this.id }, { header })
+      axios.delete(url, { id: this.id }, { headers })
         .then(response => {
           switch (response.status) {
             case 200:

--- a/src/components/inputs/PINInput.vue
+++ b/src/components/inputs/PINInput.vue
@@ -41,7 +41,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 200:
-              return response.json();
+              return response.data;
             default:
               this.$swal.fire({
                 icon: 'error',

--- a/src/services.js
+++ b/src/services.js
@@ -1,5 +1,5 @@
 export const getUrl = url => `${process.env.VUE_APP_BASE_URL}/${url}`;
 
 export const getHeader = () => ({
-  'AccessToken': localStorage.getItem('token')
+  'Access-Token': localStorage.getItem('token')
 })

--- a/src/views/Landing.vue
+++ b/src/views/Landing.vue
@@ -10,7 +10,7 @@
 
     <footer class="absolute bottom-0 p-5 w-full grid place-content-center z-10">
       <p class="font-medium text-light">
-        Browse our exciting game modes <router-link to="/browse" class="underline hover:text-cc">here</router-link>!
+        Start your own game or browse our exciting game modes <router-link to="/browse" class="underline hover:text-cc">here</router-link>!
       </p>
     </footer>
 

--- a/src/views/gameModes/bb/BBCreate.vue
+++ b/src/views/gameModes/bb/BBCreate.vue
@@ -66,7 +66,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 200:
-              return response.json();
+              return response.data;
             default:
               return;
           }
@@ -92,7 +92,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 201:
-              return response.json();
+              return response.data;
             default:
               throw new Error('Bad method!');
           }
@@ -113,7 +113,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 201:
-              return response.json();
+              return response.data;
             default:
               throw new Error('Bad method!');
           }

--- a/src/views/gameModes/bb/BBCreate.vue
+++ b/src/views/gameModes/bb/BBCreate.vue
@@ -61,8 +61,8 @@ export default {
   },
   methods: {
     async populate({ url }) {
-      const header = getHeader();
-      axios.get(url, {}, { header })
+      const headers = getHeader();
+      axios.get(url, {}, { headers })
         .then(response => {
           switch (response.status) {
             case 200:
@@ -87,8 +87,8 @@ export default {
         bbContext: this.$refs.bb.getValues()
       };
       const url = getUrl('bb/questions/generate');
-      const header = getHeader();
-      axios.post(url, payload, { header })
+      const headers = getHeader();
+      axios.post(url, payload, { headers })
         .then(response => {
           switch (response.status) {
             case 201:
@@ -108,8 +108,8 @@ export default {
     },
     async createRoom() {
       const url = getUrl('bb/create');
-      const header = getHeader();
-      axios.post(url, {}, { header })
+      const headers = getHeader();
+      axios.post(url, {}, { headers })
         .then(response => {
           switch (response.status) {
             case 201:

--- a/src/views/gameModes/bb/BBRoom.vue
+++ b/src/views/gameModes/bb/BBRoom.vue
@@ -56,7 +56,7 @@ export default {
       .then(response => {
         switch (response.status) {
           case 200:
-            return response.json()
+            return response.data
           default:
             this.$router.push('.');
             this.$swal.fire({

--- a/src/views/gameModes/csc/CSCCreate.vue
+++ b/src/views/gameModes/csc/CSCCreate.vue
@@ -61,8 +61,8 @@ export default {
   },
   methods: {
     async populate({ url }) {
-      const header = getHeader();
-      axios.get(url, {}, { header })
+      const headers = getHeader();
+      axios.get(url, {}, { headers })
         .then(response => {
           switch (response.status) {
             case 200:
@@ -87,8 +87,8 @@ export default {
         cscContext: this.$refs.csc.getValues()
       };
       const url = getUrl('csc/questions/generate');
-      const header = getHeader();
-      axios.post(url, payload, { header })
+      const headers = getHeader();
+      axios.post(url, payload, { headers })
         .then(response => {
           switch (response.status) {
             case 201:
@@ -108,8 +108,8 @@ export default {
     },
     async createRoom() {
       const url = getUrl('csc/create');
-      const header = getHeader();
-      axios.post(url, {}, { header })
+      const headers = getHeader();
+      axios.post(url, {}, { headers })
         .then(response => {
           switch (response.status) {
             case 201:

--- a/src/views/gameModes/csc/CSCCreate.vue
+++ b/src/views/gameModes/csc/CSCCreate.vue
@@ -66,7 +66,7 @@ export default {
         .then(response => {
           switch (response.status) {
             case 200:
-              return response.json();
+              return response.data;
             default:
               return;
           }
@@ -92,13 +92,14 @@ export default {
         .then(response => {
           switch (response.status) {
             case 201:
-              return response.json();
+              return response.data;
             default:
               throw new Error('Bad method!');
           }
         })
         .then(data => {
           this.questions = data.questions;
+          console.log(this.questions);
         })
         .catch(err => {
           console.log(err);
@@ -107,13 +108,13 @@ export default {
         })
     },
     async createRoom() {
-      const url = getUrl('csc/create');
+      const url = getUrl('room/csc/create');
       const headers = getHeader();
       axios.post(url, {}, { headers })
         .then(response => {
           switch (response.status) {
             case 201:
-              return response.json();
+              return response.data;
             default:
               throw new Error('Bad method!');
           }

--- a/src/views/gameModes/csc/CSCRoom.vue
+++ b/src/views/gameModes/csc/CSCRoom.vue
@@ -71,7 +71,7 @@ export default {
       .then(response => {
         switch (response.status) {
           case 200:
-            return response.json()
+            return response.data
           default:
             this.$router.push('.');
             this.$swal.fire({


### PR DESCRIPTION
Fix: axios expects `headers` plural instead of `header`. Before this change, axios doesn't include the custom data (access token) in the headers it sends to the backend. I also changed the accesstoken name to Access-Token to sync with the name the backend expects. 

Fix: `response.json()` throws an error in axios as axios automatically parses the JSON response (?). Changed `response.json()` to `response.data`
This is the error for reference:
`CSCCreate.vue:104 TypeError: response.json is not a function
    at eval (CSCCreate.vue:95:1)`

Bug: Successfully setting this.questions to the returned questions doesn't update the frontend page to show me the generated questions.

 Bug?: Creating room brings me to 404 not found page